### PR TITLE
Enable ACE Captivity

### DIFF
--- a/Includes/scripts/description.ext
+++ b/Includes/scripts/description.ext
@@ -17,6 +17,11 @@ class CfgSounds
 
 };
 
+class ace_captives_captivityEnabled {
+    value = 1;
+    typeName = "BOOL";
+    force = 1;
+};
 
 respawn = 3;
 respawnDelay = 9999999999;

--- a/Includes/scripts/init.sqf
+++ b/Includes/scripts/init.sqf
@@ -3,6 +3,10 @@ enableRadio false;
 
 //tf_no_auto_long_range_radio = true; // Causes the exact opposite effect REMOVE FOR NOW
 
+ace_captives_captivityEnabled = true;
+
+if(isServer) then { sleep 3; ace_captives_captivityEnabled = true; };
+
 []spawn {
 	while {true} do {{
 		deleteGroup _x
@@ -11,3 +15,5 @@ enableRadio false;
 	sleep 601;
 	};
 }; // Fix Zeus group bug (will remove deleted groups so more can be added)
+
+


### PR DESCRIPTION
For some reason ace_captives_captivityEnabled isnt enabled by default on dedicated envirnoment.
Apply every fix as per SOP.

Add additional game logic with
`ace_captives_captivityEnabled = true;`